### PR TITLE
Enable analysis job submission to Expanse

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -12,10 +12,18 @@ database:
     build_indexes: True
 
 expanse:
-    host: login.expanse.sdsc.edu
-    port: 22
-    username:
-    password:
+    ssh:
+        host: login.expanse.sdsc.edu
+        port: 22
+        username:
+        password:
+    nmma_dir:
+    data_dirname:
+
+local:
+    nmma_dir:
+    data_dirname:
+    slurm_script_name:
 
 ports:
     api: 4000

--- a/nmma_api/services/api.py
+++ b/nmma_api/services/api.py
@@ -8,7 +8,7 @@ import tornado.web
 from nmma_api.utils.config import load_config
 from nmma_api.utils.logs import make_log
 from nmma_api.utils.mongo import Mongo, init_db
-from nmma_api.tools.expanse import validate_credentials
+from nmma_api.tools.expanse import validate_credentials, submit
 
 log = make_log("main")
 
@@ -77,6 +77,10 @@ class MainHandler(tornado.web.RequestHandler):
         }
         mongo.insert_one("analysis", data)
 
+        # If some amount of time has passed, query and pass a list of pending analyses to Expanse submission code.
+        # (Can use another script to keep track, and perhaps add a flag here specifying whether to submit or not?)
+        submit([data_dict])
+
         return self.write(
             {
                 "status": "pending",
@@ -121,5 +125,7 @@ def make_app():
 if __name__ == "__main__":
     init_db(config)
     app = make_app()
-    app.listen(config["ports"]["api"])
+    port = config["ports"]["api"]
+    app.listen(port)
+    log(f"NMMA Service Listening on port {port}")
     tornado.ioloop.IOLoop.current().start()

--- a/nmma_api/services/api.py
+++ b/nmma_api/services/api.py
@@ -8,7 +8,7 @@ import tornado.web
 from nmma_api.utils.config import load_config
 from nmma_api.utils.logs import make_log
 from nmma_api.utils.mongo import Mongo, init_db
-from nmma_api.tools.expanse import validate_credentials, submit
+from nmma_api.tools.expanse import validate_credentials
 
 log = make_log("main")
 
@@ -76,10 +76,6 @@ class MainHandler(tornado.web.RequestHandler):
             "created_at": datetime.timestamp(datetime.utcnow()),
         }
         mongo.insert_one("analysis", data)
-
-        # If some amount of time has passed, query and pass a list of pending analyses to Expanse submission code.
-        # (Can use another script to keep track, and perhaps add a flag here specifying whether to submit or not?)
-        submit([data_dict])
 
         return self.write(
             {

--- a/nmma_api/services/submission_queue.py
+++ b/nmma_api/services/submission_queue.py
@@ -18,6 +18,9 @@ def submission_queue():
         try:
             # get the analysis requests that haven't been processed yet
             analysis_requests = mongo.db.analysis.find({"status": "pending"})
+            if len(analysis_requests) == 0:
+                time.sleep(60)
+                continue
             submit(analysis_requests)
             for analysis_request in analysis_requests:
                 mongo.db.analysis.update_one(
@@ -27,7 +30,7 @@ def submission_queue():
         except Exception as e:
             log(f"Failed to submit analysis requests to expanse: {e}")
 
-        time.sleep(10)
+        time.sleep(60)
 
 
 if __name__ == "__main__":

--- a/nmma_api/tools/expanse.py
+++ b/nmma_api/tools/expanse.py
@@ -3,8 +3,20 @@
 from nmma_api.utils.logs import make_log
 from nmma_api.utils.config import load_config
 from paramiko.client import SSHClient, AutoAddPolicy
+from astropy.table import Table
+from astropy.time import Time
+import numpy as np
+import os
+import warnings
 
 config = load_config()
+
+local_nmma_dir = config['local']['nmma_dir']
+local_data_dirname = config['local']['data_dirname']
+expanse_nmma_dir = config['expanse']['nmma_dir']
+expanse_data_dirname = config['expanse']['data_dirname']
+
+slurm_script_name = config['local']['slurm_script_name']
 
 log = make_log("expanse")
 
@@ -28,7 +40,7 @@ class Expanse:
         self.client.close()
 
 
-expanse = Expanse(**config["expanse"])
+expanse = Expanse(**config["expanse"]["ssh"])
 
 
 def validate_credentials() -> bool:
@@ -47,6 +59,85 @@ def submit(analyses: list[dict], **kwargs) -> bool:
     """Submit an analysis to expanse."""
 
     # TODO: Implement this function
+
+    # get structure of analyses dict
+    for data_dict in analyses:
+        analysis_parameters = data_dict["inputs"].get("analysis_parameters", {})
+
+        MODEL = analysis_parameters.get("source")
+        resource_id = data_dict.get("resource_id", "")
+        LABEL = f"{resource_id}_{MODEL}"
+        TMIN = analysis_parameters.get("tmin")
+        TMAX = analysis_parameters.get("tmax")
+        DT = analysis_parameters.get("dt")
+
+        # this example analysis service expects the photometry to be in
+        # a csv file (at data_dict["inputs"]["photometry"]) with the following columns
+        # - filter: the name of the bandpass
+        # - mjd: the modified Julian date of the observation
+        # - magsys: the mag system (e.g. ab) of the observations
+        # - flux: the flux of the observation
+        #
+        # the following code transforms these inputs from SkyPortal
+        # to the format expected by nmma.
+        #
+        rez = {"status": "failure", "message": "", "analysis": {}}
+
+        try:
+            data = Table.read(data_dict["inputs"]["photometry"], format="ascii.csv")
+            redshift = Table.read(data_dict["inputs"]["redshift"], format="ascii.csv")
+            z = redshift["redshift"][0]
+        except Exception as e:
+            rez.update(
+                {
+                    "status": "failure",
+                    "message": f"input data is not in the expected format {e}",
+                }
+            )
+            return rez
+        
+        # Set trigger time based on first detection
+        TT = np.min(data[data["mag"] != np.ma.masked]["mjd"])
+
+        # Give each source a different filename. This file will be copied to Expanse.
+        filename = f'{resource_id}.dat'
+        local_data_dir = os.path.join(local_nmma_dir, local_data_dirname)
+        os.makedirs(local_data_dir, exist_ok=True)
+
+        local_data_path = os.path.join(local_data_dir, filename)
+        with open(local_data_path, 'w') as f:
+            # output the data in the format desired by NMMA:
+            # remove rows where mag and magerr are missing, or not float, or negative
+            data = data[
+                np.isfinite(data["mag"])
+                & np.isfinite(data["magerr"])
+                & (data["mag"] > 0)
+                & (data["magerr"] > 0)
+            ]
+            for row in data:
+                tt = Time(row["mjd"], format="mjd").isot
+                filt = row["filter"]
+                mag = row["mag"]
+                magerr = row["magerr"]
+                f.write(f"{tt} {filt} {mag} {magerr}\n")
+
+        expanse_data_dir = os.path.join(expanse_nmma_dir, expanse_data_dirname)
+        expanse.client.exec_command(f'mkdir {expanse_data_dir}')
+
+        expanse_data_path = os.path.join(expanse_data_dir, filename)
+
+        sftp = expanse.client.open_sftp()
+        sftp.put(local_data_path, expanse_data_path)
+        sftp.close()
+
+        DATA = expanse_data_path
+
+        _, stdout, stderr = expanse.client.exec_command(f'cd {expanse_nmma_dir}; sbatch --export=MODEL={MODEL},LABEL={LABEL},TT={TT},DATA={DATA},TMIN={TMIN},TMAX={TMAX},DT={DT} {slurm_script_name}')
+        print(stdout.read().decode('utf-8'))
+        submit_error = stderr.read().decode('utf-8')
+        if submit_error != '':
+            warnings.warn(f'Submission error: {submit_error}')
+        
     return True
 
 

--- a/nmma_api/tools/expanse.py
+++ b/nmma_api/tools/expanse.py
@@ -11,12 +11,12 @@ import warnings
 
 config = load_config()
 
-local_nmma_dir = config['local']['nmma_dir']
-local_data_dirname = config['local']['data_dirname']
-expanse_nmma_dir = config['expanse']['nmma_dir']
-expanse_data_dirname = config['expanse']['data_dirname']
+local_nmma_dir = config["local"]["nmma_dir"]
+local_data_dirname = config["local"]["data_dirname"]
+expanse_nmma_dir = config["expanse"]["nmma_dir"]
+expanse_data_dirname = config["expanse"]["data_dirname"]
 
-slurm_script_name = config['local']['slurm_script_name']
+slurm_script_name = config["local"]["slurm_script_name"]
 
 log = make_log("expanse")
 
@@ -58,8 +58,6 @@ def validate_credentials() -> bool:
 def submit(analyses: list[dict], **kwargs) -> bool:
     """Submit an analysis to expanse."""
 
-    # TODO: Implement this function
-
     # get structure of analyses dict
     for data_dict in analyses:
         analysis_parameters = data_dict["inputs"].get("analysis_parameters", {})
@@ -86,7 +84,7 @@ def submit(analyses: list[dict], **kwargs) -> bool:
         try:
             data = Table.read(data_dict["inputs"]["photometry"], format="ascii.csv")
             redshift = Table.read(data_dict["inputs"]["redshift"], format="ascii.csv")
-            z = redshift["redshift"][0]
+            z = redshift["redshift"][0]  # noqa F841
         except Exception as e:
             rez.update(
                 {
@@ -95,17 +93,17 @@ def submit(analyses: list[dict], **kwargs) -> bool:
                 }
             )
             return rez
-        
+
         # Set trigger time based on first detection
         TT = np.min(data[data["mag"] != np.ma.masked]["mjd"])
 
         # Give each source a different filename. This file will be copied to Expanse.
-        filename = f'{resource_id}.dat'
+        filename = f"{resource_id}.dat"
         local_data_dir = os.path.join(local_nmma_dir, local_data_dirname)
         os.makedirs(local_data_dir, exist_ok=True)
 
         local_data_path = os.path.join(local_data_dir, filename)
-        with open(local_data_path, 'w') as f:
+        with open(local_data_path, "w") as f:
             # output the data in the format desired by NMMA:
             # remove rows where mag and magerr are missing, or not float, or negative
             data = data[
@@ -122,7 +120,7 @@ def submit(analyses: list[dict], **kwargs) -> bool:
                 f.write(f"{tt} {filt} {mag} {magerr}\n")
 
         expanse_data_dir = os.path.join(expanse_nmma_dir, expanse_data_dirname)
-        expanse.client.exec_command(f'mkdir {expanse_data_dir}')
+        expanse.client.exec_command(f"mkdir {expanse_data_dir}")
 
         expanse_data_path = os.path.join(expanse_data_dir, filename)
 
@@ -132,17 +130,25 @@ def submit(analyses: list[dict], **kwargs) -> bool:
 
         DATA = expanse_data_path
 
-        _, stdout, stderr = expanse.client.exec_command(f'cd {expanse_nmma_dir}; sbatch --export=MODEL={MODEL},LABEL={LABEL},TT={TT},DATA={DATA},TMIN={TMIN},TMAX={TMAX},DT={DT} {slurm_script_name}')
-        print(stdout.read().decode('utf-8'))
-        submit_error = stderr.read().decode('utf-8')
-        if submit_error != '':
-            warnings.warn(f'Submission error: {submit_error}')
-        
+        _, stdout, stderr = expanse.client.exec_command(
+            f"cd {expanse_nmma_dir}; sbatch --export=MODEL={MODEL},LABEL={LABEL},TT={TT},DATA={DATA},TMIN={TMIN},TMAX={TMAX},DT={DT} {slurm_script_name}"
+        )
+        print(stdout.read().decode("utf-8"))
+        submit_error = stderr.read().decode("utf-8")
+        if submit_error != "":
+            warnings.warn(f"Submission error: {submit_error}")
+
     return True
 
 
 def retrieve() -> list[dict]:
     """Retrieve analyses results from expanse."""
+    # retrieve the results from expanse
+    # look into the expanse directory for the results
+    # copy the results to the local directory
+    # update the database
+    # return the results
+    return []  # TODO: implement this method
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ supervisor
 fire
 paramiko
 pre-commit
+astropy


### PR DESCRIPTION
This PR enables NMMA analyses to be submitted to Expanse via SkyPortal. The `data_dict` provided by SkyPortal is reformatted, saved, and copied to Expanse. Then, a pre-existing slurm script (generated using `tools/analysis_slurm.py` in the main NMMA repo) is queued with custom arguments.