### PR TITLE
Handle mongoDB cursor object in submission code

### DIFF
--- a/nmma_api/services/submission_queue.py
+++ b/nmma_api/services/submission_queue.py
@@ -17,7 +17,8 @@ def submission_queue():
     while True:
         try:
             # get the analysis requests that haven't been processed yet
-            analysis_requests = mongo.db.analysis.find({"status": "pending"})
+            analysis_cursor = mongo.db.analysis.find({"status": "pending"})
+            analysis_requests = [x for x in analysis_cursor]
             if len(analysis_requests) == 0:
                 time.sleep(60)
                 continue


### PR DESCRIPTION
This PR reformats the output of the mongoDB query for pending sources in `submission_queue.py` to avoid the following error: 
`Failed to submit analysis requests to expanse: object of type 'Cursor' has no len()`