### PR TITLE
Resubmit expired jobs to make plots using new NMMA flag

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -20,6 +20,7 @@ expanse:
   nmma_dir:
   data_dirname:
   output_dirname:
+  time_limit: 6 # in hours
 
 local:
   nmma_dir:

--- a/nmma_api/services/retrieval_queue.py
+++ b/nmma_api/services/retrieval_queue.py
@@ -1,7 +1,7 @@
 import time
 from datetime import datetime
 
-from nmma_api.tools.expanse import retrieve, cancel_job
+from nmma_api.tools.expanse import retrieve, cancel_job, submit  # noqa 401
 from nmma_api.tools.webhook import upload_analysis_results
 from nmma_api.utils.config import load_config
 from nmma_api.utils.logs import make_log
@@ -49,6 +49,11 @@ def retrieval_queue():
                         {"_id": analysis["_id"]},
                         {"$set": {"status": "expired"}},
                     )
+
+                    # Option B: immediately resubmit expired analyses to make plots
+                    # submit(analysis)
+                    # Modify deletion code below
+
                     try:
                         mongo.db.results.delete_one({"analysis_id": analysis["_id"]})
                     except Exception:

--- a/nmma_api/services/retrieval_queue.py
+++ b/nmma_api/services/retrieval_queue.py
@@ -1,7 +1,7 @@
 import time
 from datetime import datetime
 
-from nmma_api.tools.expanse import retrieve, cancel_job, submit  # noqa 401
+from nmma_api.tools.expanse import retrieve, cancel_job  # noqa 401
 from nmma_api.tools.webhook import upload_analysis_results
 from nmma_api.utils.config import load_config
 from nmma_api.utils.logs import make_log
@@ -14,7 +14,7 @@ config = load_config()
 mongo = Mongo(**config["database"])
 retrieval_wait_time = config["wait_times"]["retrieval"]
 max_upload_failures = config["wait_times"].get("max_upload_failures", 10)
-time_limit = config["expansion"].get("time_limit", 6) * 3600  # in seconds
+time_limit = config["expanse"].get("time_limit", 6) * 3600  # in seconds
 
 if time_limit > 24 * 3600:
     raise ValueError("time_limit cannot be greater than 24 hours")

--- a/nmma_api/services/submission_queue.py
+++ b/nmma_api/services/submission_queue.py
@@ -19,28 +19,31 @@ def submission_queue():
     while True:
         try:
             # get the analysis requests that haven't been processed yet
-            analysis_cursor = mongo.db.analysis.find({"status": "pending"})
-
-            # Option A: submit jobs marked as "pending" or "expired"
-            # analysis_cursor = mongo.db.analysis.find({"status": ["pending", "expired"]})
-            # Then, change "expired" jobs to some other status below
+            analysis_cursor = mongo.db.analysis.find(
+                {"status": {"$in": ["pending", "job_expired"]}}
+            )
 
             analysis_requests = [x for x in analysis_cursor]
-            log(f"Found {len(analysis_requests)} analysis requests to submit.")
+            log(
+                f"Found {len(analysis_requests)} analysis requests to submit or resubmit."
+            )
             if len(analysis_requests) == 0:
                 time.sleep(submission_wait_time)
                 continue
             jobs = submit(analysis_requests)
             for analysis_request in analysis_requests:
-                job_id = jobs.get(analysis_request["_id"], {}).get("job_id")
+                job = jobs.get(analysis_request["_id"], {})
                 error = jobs.get(analysis_request["_id"], {}).get("error", "")
-                if job_id is not None:
+                if job.get("job_id") is not None:
                     mongo.db.analysis.update_one(
                         {"_id": analysis_request["_id"]},
                         {
                             "$set": {
-                                "status": "running",
-                                "job_id": job_id,
+                                "status": "running_plot"
+                                if analysis_request["status"] == "job_expired"
+                                else "running",
+                                "job_id": job.get("job_id"),
+                                "submitted_at": job.get("submitted_at"),
                             }
                         },
                     )

--- a/nmma_api/services/submission_queue.py
+++ b/nmma_api/services/submission_queue.py
@@ -20,6 +20,11 @@ def submission_queue():
         try:
             # get the analysis requests that haven't been processed yet
             analysis_cursor = mongo.db.analysis.find({"status": "pending"})
+
+            # Option A: submit jobs marked as "pending" or "expired"
+            # analysis_cursor = mongo.db.analysis.find({"status": ["pending", "expired"]})
+            # Then, change "expired" jobs to some other status below
+
             analysis_requests = [x for x in analysis_cursor]
             log(f"Found {len(analysis_requests)} analysis requests to submit.")
             if len(analysis_requests) == 0:

--- a/nmma_api/tools/expanse.py
+++ b/nmma_api/tools/expanse.py
@@ -81,6 +81,7 @@ def submit(analyses: list[dict], **kwargs) -> bool:
             try:
                 analysis_parameters = data_dict["inputs"].get("analysis_parameters", {})
                 timestamp = data_dict.get("created_at", None)
+                status = data_dict.get("status", None)
 
                 MODEL = analysis_parameters.get("source")
                 resource_id = data_dict.get("resource_id", "")
@@ -88,6 +89,9 @@ def submit(analyses: list[dict], **kwargs) -> bool:
                 TMIN = analysis_parameters.get("tmin")
                 TMAX = analysis_parameters.get("tmax")
                 DT = analysis_parameters.get("dt")
+                SKIP_SAMPLING = ""
+                if status == "expired":
+                    SKIP_SAMPLING = "--skip-sampling"
 
                 # this example analysis service expects the photometry to be in
                 # a csv file (at data_dict["inputs"]["photometry"]) with the following columns
@@ -152,7 +156,7 @@ def submit(analyses: list[dict], **kwargs) -> bool:
                 DATA = expanse_data_path
 
                 _, stdout, stderr = expanse.client.exec_command(
-                    f"cd {expanse_nmma_dir}; sbatch --export=MODEL={MODEL},LABEL={LABEL},TT={TT},DATA={DATA},TMIN={TMIN},TMAX={TMAX},DT={DT} {slurm_script_name}"
+                    f"cd {expanse_nmma_dir}; sbatch --export=MODEL={MODEL},LABEL={LABEL},TT={TT},DATA={DATA},TMIN={TMIN},TMAX={TMAX},DT={DT},SKIP_SAMPLING={SKIP_SAMPLING} {slurm_script_name}"
                 )
             except Exception as e:
                 raise ValueError(f"failed to submit job {e}")

--- a/nmma_api/tools/expanse.py
+++ b/nmma_api/tools/expanse.py
@@ -4,6 +4,7 @@ import json
 import os
 import tempfile
 import warnings
+from datetime import datetime
 
 import arviz as az
 import joblib
@@ -90,7 +91,7 @@ def submit(analyses: list[dict], **kwargs) -> bool:
                 TMAX = analysis_parameters.get("tmax")
                 DT = analysis_parameters.get("dt")
                 SKIP_SAMPLING = ""
-                if status == "expired":
+                if status == "job_expired":
                     SKIP_SAMPLING = "--skip-sampling"
 
                 # this example analysis service expects the photometry to be in
@@ -169,7 +170,11 @@ def submit(analyses: list[dict], **kwargs) -> bool:
                 raise ValueError(f"Submission error: {submit_error}")
             else:
                 job_id = int(submit_message.split(" ")[-1].strip())
-                jobs[data_dict["_id"]] = {"job_id": job_id, "message": ""}
+                jobs[data_dict["_id"]] = {
+                    "job_id": job_id,
+                    "message": "",
+                    "submitted_at": datetime.timestamp(datetime.utcnow()),
+                }
                 log(f"Submitted job {job_id} for analysis {data_dict['_id']}")
         except Exception as e:
             log(f"Failed to submit analysis {data_dict['_id']} to expanse: {e}")


### PR DESCRIPTION
This PR proposes two pseudocode ways to resubmit expired analysis jobs using the `--skip-sampling` flag (https://github.com/nuclear-multimessenger-astronomy/nmma/pull/266) to generate plots from the latest checkpoint results.

Option A: modify submission code to submit both `pending` and `expired` jobs. If a job is marked as `expired`, use the `--skip-sapmling` option in NMMA analysis. Afterward, change each `expired` job to some other status.

Option B: modify retrieval code to submit expired jobs immediately once they are identified.

In each case, we might not want to delete `expired` jobs from the database if we're fetching results plots from them. 