### PR TITLE
Decrease size of analysis results uploaded to SkyPortal

### DIFF
--- a/nmma_api/tools/expanse.py
+++ b/nmma_api/tools/expanse.py
@@ -245,6 +245,11 @@ def retrieve(analysis: dict) -> dict:
         with open(local_json_file) as f:
             result = json.load(f)
         log_bayes_factor = result["log_bayes_factor"]
+
+        # Remove some keys to maintain a reasonable results size
+        pop_list = ["samples", "nested_samples", "log_likelihood_evaluations"]
+        [result.pop(x) for x in pop_list]
+
         f = tempfile.NamedTemporaryFile(suffix=".png", prefix="nmmaplot_", delete=False)
         f.close()
 

--- a/nmma_api/tools/expanse.py
+++ b/nmma_api/tools/expanse.py
@@ -247,7 +247,7 @@ def retrieve(analysis: dict) -> dict:
         log_bayes_factor = result["log_bayes_factor"]
 
         # Remove some keys to maintain a reasonable results size
-        pop_list = ["samples", "nested_samples", "log_likelihood_evaluations"]
+        pop_list = ["samples", "nested_samples"]
         [result.pop(x) for x in pop_list]
 
         f = tempfile.NamedTemporaryFile(suffix=".png", prefix="nmmaplot_", delete=False)


### PR DESCRIPTION
This PR decreases the size of analysis results uploaded to SkyPortal by ~80% by removing the `samples` and `nested_samples` keys from the results dictionary. This will hopefully lighten the load on fritz and the API's mongoDB.