### PR TITLE
Drop photometry points with duplicate timestamps

### DIFF
--- a/nmma_api/services/api.py
+++ b/nmma_api/services/api.py
@@ -3,7 +3,7 @@ import gzip
 import json
 import traceback
 from datetime import datetime
-from astropy.table import Table
+from astropy.table import Table, unique
 
 import tornado.escape
 import tornado.web
@@ -47,6 +47,8 @@ def validate(data: dict) -> str:
             and len(data["inputs"]["photometry"]) > 0
         ):
             temp = Table.read(data["inputs"]["photometry"], format="ascii.csv")
+            # Drop points with duplicate timestamps
+            temp = unique(temp, keys="mjd")
             skipped = 0
             skipped_filters = []
             for row in temp:


### PR DESCRIPTION
This PR drops SkyPortal photometry points that have duplicate timestamps, keeping only the first of these (see https://github.com/nuclear-multimessenger-astronomy/nmma/pull/282 for more discussion).